### PR TITLE
Fix style tests for flake8 >= 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "nose",
         "mock",
         "coverage",
-        "flake8",
+        "flake8>=3.0.0",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/style_tests.py
+++ b/tests/style_tests.py
@@ -1,7 +1,6 @@
 import os
 
-import flake8.main
-import six
+from flake8.api import legacy as flake8
 
 
 MAX_COMPLEXITY = 11
@@ -28,6 +27,7 @@ def create_style_assert(path, python_files):
         assert_conforms_to_style(python_files)
 
     test_name = "test_style__%s" % path
+
     test_function.__name__ = test_name
     test_function.description = test_name
 
@@ -35,14 +35,18 @@ def create_style_assert(path, python_files):
 
 
 def assert_conforms_to_style(python_files):
-    checker = flake8.main.get_style_guide(
-        paths=python_files, max_complexity=MAX_COMPLEXITY
-    )
+    checker = flake8.get_style_guide(max_complexity=MAX_COMPLEXITY)
+
     checker.options.jobs = 1
     checker.options.verbose = True
-    result = checker.check_files()
+    report = checker.check_files(python_files)
 
-    assert not result.messages, "\n".join([
-        "%s: %s" % (code, message)
-        for code, message in six.iteritems(result.messages)
+    warnings = report.get_statistics("W")
+    errors = report.get_statistics("E")
+
+    assert not (warnings or errors), "\n" + "\n".join([
+        "Warnings:",
+        "\n".join(warnings),
+        "Errors:",
+        "\n".join(errors),
     ])


### PR DESCRIPTION
The API changed slightly in the flake8 update to 3.0.0.  Since the setup file's version
wasn't pinned to a version, CI runs would download the latest and the style tests would
fail with a message about `get_style_guide` not existing.