### PR TITLE
Use unicode literals absolutely everywhere.

### DIFF
--- a/zoonado/client.py
+++ b/zoonado/client.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 from tornado import gen, concurrent

--- a/zoonado/compat.py
+++ b/zoonado/compat.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 def add_metaclass(metaclass):
     """
     Class decorator for creating a class with a metaclass.

--- a/zoonado/connection.py
+++ b/zoonado/connection.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import logging
 import re

--- a/zoonado/exc.py
+++ b/zoonado/exc.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .compat import add_metaclass
 
 

--- a/zoonado/features.py
+++ b/zoonado/features.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 ALL_FEATURES = {
     "create_with_stat": (3, 5, 0),
     "containers": (3, 5, 1),

--- a/zoonado/iterables.py
+++ b/zoonado/iterables.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+
 def drain(iterable):
     """
     Helper method that empties an iterable as it is iterated over.

--- a/zoonado/protocol/acl.py
+++ b/zoonado/protocol/acl.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .part import Part

--- a/zoonado/protocol/auth.py
+++ b/zoonado/protocol/auth.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import Int, Buffer, UString

--- a/zoonado/protocol/check.py
+++ b/zoonado/protocol/check.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import Int, UString

--- a/zoonado/protocol/children.py
+++ b/zoonado/protocol/children.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .stat import Stat

--- a/zoonado/protocol/close.py
+++ b/zoonado/protocol/close.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 

--- a/zoonado/protocol/connect.py
+++ b/zoonado/protocol/connect.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import Int, Long, Buffer, Bool

--- a/zoonado/protocol/create.py
+++ b/zoonado/protocol/create.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .stat import Stat

--- a/zoonado/protocol/data.py
+++ b/zoonado/protocol/data.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .stat import Stat

--- a/zoonado/protocol/delete.py
+++ b/zoonado/protocol/delete.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import UString, Int

--- a/zoonado/protocol/exists.py
+++ b/zoonado/protocol/exists.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .stat import Stat

--- a/zoonado/protocol/part.py
+++ b/zoonado/protocol/part.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import operator
 
 from .primitives import Primitive

--- a/zoonado/protocol/ping.py
+++ b/zoonado/protocol/ping.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 

--- a/zoonado/protocol/primitives.py
+++ b/zoonado/protocol/primitives.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import struct
 
 
@@ -198,7 +200,7 @@ class Vector(Primitive):
         Creates a new class with the ``item_class`` attribute properly set.
         """
         copy = type(
-            "VectorOf%s" % part_class.__name__,
+            str("VectorOf%s" % part_class.__name__),
             cls.__bases__, dict(cls.__dict__)
         )
         copy.item_class = part_class

--- a/zoonado/protocol/reconfig.py
+++ b/zoonado/protocol/reconfig.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .stat import Stat

--- a/zoonado/protocol/request.py
+++ b/zoonado/protocol/request.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import struct
 

--- a/zoonado/protocol/response.py
+++ b/zoonado/protocol/response.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from zoonado.compat import add_metaclass
 
 from .part import Part

--- a/zoonado/protocol/sasl.py
+++ b/zoonado/protocol/sasl.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import Buffer

--- a/zoonado/protocol/stat.py
+++ b/zoonado/protocol/stat.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .part import Part
 from .primitives import Long, Int
 

--- a/zoonado/protocol/sync.py
+++ b/zoonado/protocol/sync.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import UString

--- a/zoonado/protocol/transaction.py
+++ b/zoonado/protocol/transaction.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import struct
 

--- a/zoonado/protocol/watches.py
+++ b/zoonado/protocol/watches.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from .request import Request
 from .response import Response
 from .primitives import Int, Long, Vector, UString

--- a/zoonado/recipes/allocator.py
+++ b/zoonado/recipes/allocator.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import itertools
 import json

--- a/zoonado/recipes/barrier.py
+++ b/zoonado/recipes/barrier.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import time
 
 from tornado import gen

--- a/zoonado/recipes/base_lock.py
+++ b/zoonado/recipes/base_lock.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import contextlib
 import logging
 import time

--- a/zoonado/recipes/base_watcher.py
+++ b/zoonado/recipes/base_watcher.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import logging
 

--- a/zoonado/recipes/children_watcher.py
+++ b/zoonado/recipes/children_watcher.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 from zoonado import WatchEvent
 

--- a/zoonado/recipes/counter.py
+++ b/zoonado/recipes/counter.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 from tornado import gen, concurrent

--- a/zoonado/recipes/data_watcher.py
+++ b/zoonado/recipes/data_watcher.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 from zoonado import WatchEvent
 

--- a/zoonado/recipes/double_barrier.py
+++ b/zoonado/recipes/double_barrier.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import time
 

--- a/zoonado/recipes/election.py
+++ b/zoonado/recipes/election.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import time
 
 from tornado import gen, ioloop, concurrent

--- a/zoonado/recipes/lease.py
+++ b/zoonado/recipes/lease.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import time
 

--- a/zoonado/recipes/lock.py
+++ b/zoonado/recipes/lock.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 
 from zoonado import exc

--- a/zoonado/recipes/party.py
+++ b/zoonado/recipes/party.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen, concurrent
 
 from .children_watcher import ChildrenWatcher

--- a/zoonado/recipes/proxy.py
+++ b/zoonado/recipes/proxy.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import pkg_resources
 

--- a/zoonado/recipes/recipe.py
+++ b/zoonado/recipes/recipe.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 
 from zoonado import exc

--- a/zoonado/recipes/sequential.py
+++ b/zoonado/recipes/sequential.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import re
 import uuid

--- a/zoonado/recipes/shared_lock.py
+++ b/zoonado/recipes/shared_lock.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 
 from zoonado import exc

--- a/zoonado/recipes/tree_cache.py
+++ b/zoonado/recipes/tree_cache.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 import six

--- a/zoonado/retry.py
+++ b/zoonado/retry.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import logging
 import time

--- a/zoonado/session.py
+++ b/zoonado/session.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import logging
 import random

--- a/zoonado/states.py
+++ b/zoonado/states.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import logging
 

--- a/zoonado/transaction.py
+++ b/zoonado/transaction.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from tornado import gen
 
 from zoonado import protocol


### PR DESCRIPTION
This will make it easier to make sure the library is fully compatible
between 2.7 and 3.x, as spelled out in the python docs themselves:

https://docs.python.org/3/howto/pyporting.html#text-versus-binary-data