### PR TITLE
Skip style tests on pypy environment.

### DIFF
--- a/tests/style_tests.py
+++ b/tests/style_tests.py
@@ -2,11 +2,21 @@ import os
 
 from flake8.api import legacy as flake8
 
+try:
+    import __pypy__  # noqa
+    is_pypy = True
+except ImportError:
+    is_pypy = False
+
 
 MAX_COMPLEXITY = 11
 
 
 def test_style():
+    if is_pypy:
+        # TODO(wglass): these are incredibly slow in pypy for some reason
+        return
+
     for path in ("zoonado", "tests", "examples"):
         python_files = list(get_python_files(path))
         yield create_style_assert(path, python_files)


### PR DESCRIPTION
For whatever reason the style tests have become incredibly slow on pypy
and will sometimes hang inside Travis's environment.

The test still runs for python 2.7 and 3.5 so nothing is missed here.