### PR TITLE
Some fixes for examples.

### DIFF
--- a/examples/party.py
+++ b/examples/party.py
@@ -49,3 +49,5 @@ def worker(number, client, args):
             yield gen.sleep(1)
             log.info("[WORKER #%d] Rejoining the party", number)
             yield party.join()
+
+    yield party.leave()

--- a/zoonado/recipes/recipe.py
+++ b/zoonado/recipes/recipe.py
@@ -26,8 +26,8 @@ class Recipe(object):
 
     def set_client(self, client):
         self.client = client
-        for sub_recipe in self.sub_recipes:
-            getattr(self, sub_recipe).client = client
+        for sub_recipe in self.sub_recipes.keys():
+            getattr(self, sub_recipe).set_client(client)
 
     @classmethod
     def validate_dependencies(cls):

--- a/zoonado/recipes/tree_cache.py
+++ b/zoonado/recipes/tree_cache.py
@@ -31,7 +31,7 @@ class TreeCache(Recipe):
 
         self.root = ZNodeCache(
             self.base_path, self.defaults,
-            self.client, self.data_watcher, self.children_watcher,
+            self.client, self.data_watcher, self.child_watcher,
         )
 
         yield self.ensure_path()
@@ -114,7 +114,7 @@ class ZNodeCache(object):
                 self.path + "/" + added, self.defaults.get(added, {}),
                 self.client, self.data_watcher, self.child_watcher
             )
-            ioloop.IOLoop.current.add_callback(self.children[added].start)
+            ioloop.IOLoop.current().add_callback(self.children[added].start)
 
     def data_callback(self, data):
         log.debug("New value for %s: %r", self.dot_path, data)


### PR DESCRIPTION
Three things:

* Fixes the setting of `self.client` on nested sub-recipes
* Updates the party example so that workers leave the "party" before the client closes
* Small fixups to the TreeCache recipe.