### PR TITLE
Fix encoding to be python 2 and 3 compatible.

### DIFF
--- a/tests/connection_tests.py
+++ b/tests/connection_tests.py
@@ -1,0 +1,74 @@
+from mock import patch, Mock, call
+from tornado import testing, concurrent
+
+from zoonado import connection
+
+
+class ConnectionTests(testing.AsyncTestCase):
+
+    def setUp(self):
+        super(ConnectionTests, self).setUp()
+
+        self.response_buffer = bytearray()
+
+        tcpclient_patcher = patch.object(connection, "tcpclient")
+        mock_tcpclient = tcpclient_patcher.start()
+        self.addCleanup(tcpclient_patcher.stop)
+
+        self.mock_client = mock_tcpclient.TCPClient.return_value
+
+        stream = Mock()
+        self.mock_client.connect.return_value = self.future_value(stream)
+
+        def read_some(num_bytes):
+            result = self.response_buffer[:num_bytes]
+            del self.response_buffer[:num_bytes]
+
+            return self.future_value(result)
+
+        def read_all():
+            result = self.response_buffer[:]
+
+            self.response_buffer = bytearray()
+
+            return self.future_value(result)
+
+        stream.write.return_value = self.future_value(None)
+        stream.read_bytes.side_effect = read_some
+        stream.read_until_close.side_effect = read_all
+
+    def future_value(self, value):
+        f = concurrent.Future()
+        f.set_result(value)
+        return f
+
+    def future_error(self, exception):
+        f = concurrent.Future()
+        f.set_exception(exception)
+        return f
+
+    @testing.gen_test
+    def test_connect_gets_version_info(self):
+        self.response_buffer.extend(
+            b"""Zookeeper version: 3.4.6-1569965, built on 02/20/2014 09:09 GMT
+Latency min/avg/max: 0/0/1137
+Received: 21462
+Sent: 21474
+Connections: 2
+Outstanding: 0
+Zxid: 0x11171
+Mode: standalone
+Node count: 232"""
+        )
+
+        conn = connection.Connection("local", 9999, Mock())
+
+        yield conn.connect()
+
+        self.assertEqual(conn.version_info, (3, 4, 6))
+        self.assertEqual(conn.start_read_only, False)
+
+        self.mock_client.connect.assert_has_calls([
+            call("local", 9999),
+            call("local", 9999),
+        ])

--- a/tests/protocol/primitives_tests.py
+++ b/tests/protocol/primitives_tests.py
@@ -163,8 +163,8 @@ class PrimitivesTests(unittest.TestCase):
 
         self.assertEqual(value, u"foobar")
 
-    def test_ustring_render_parse_handles_nonstrings(self):
-        s = primitives.UString(123)
+    def test_ustring_render_parse_handles_strings(self):
+        s = primitives.UString("bazzzz")
 
         fmt, values = s.render()
 
@@ -172,4 +172,4 @@ class PrimitivesTests(unittest.TestCase):
 
         value, _ = primitives.UString.parse(raw, 0)
 
-        self.assertEqual(value, u"123")
+        self.assertEqual(value, u"bazzzz")

--- a/zoonado/connection.py
+++ b/zoonado/connection.py
@@ -53,8 +53,10 @@ class Connection(object):
         stream = yield client.connect(self.host, self.port)
 
         log.debug("Sending 'srvr' command to %s:%d", self.host, self.port)
-        yield stream.write("srvr")
+        yield stream.write(b"srvr")
         answer = yield stream.read_until_close()
+
+        answer = answer.decode("utf8")
 
         version_line = answer.split("\n")[0]
         self.version_info = tuple(

--- a/zoonado/encoding.py
+++ b/zoonado/encoding.py
@@ -1,0 +1,27 @@
+import logging
+
+import six
+
+
+log = logging.getLogger(__name__)
+
+
+def default_encoder(data):
+    if data is None or isinstance(data, six.binary_type):
+        return data
+
+    try:
+        return data.encode("utf8")
+    except Exception:
+        log.exception("Error encoding data: %r", data)
+        raise
+
+
+def default_decoder(data):
+    if data is None:
+        return data
+
+    try:
+        return data.decode("utf8")
+    except UnicodeDecodeError:
+        return data

--- a/zoonado/protocol/primitives.py
+++ b/zoonado/protocol/primitives.py
@@ -161,14 +161,14 @@ class UString(VariablePrimitive):
     size_primitive = Int
 
     def render_value(self, value):
-        return bytes(str(value).encode("utf-8"))
+        return value.encode("utf8")
 
     @classmethod
     def parse_value(cls, value):
-        return value.decode("utf-8")
+        return value.decode("utf8")
 
     def __str__(self):
-        return str(self.value)
+        return self.value
 
 
 class Buffer(VariablePrimitive):
@@ -178,7 +178,7 @@ class Buffer(VariablePrimitive):
     size_primitive = Int
 
     def render_value(self, value):
-        return bytes(value)
+        return value
 
     @classmethod
     def parse_value(cls, value):


### PR DESCRIPTION
Introduces two new optional arguments to the `Zoonado` class for encoding and decoding of data.

With this change fewer assumptions about payloads are made, the default setup will work with raw byte types or string types.

Also fixes a small bug in the initial connection phase in python3 where a text string was used where bytes were required.

Fixes #3 (hopefully)