### PR TITLE
Fix issue #22 connection abort and recovery

### DIFF
--- a/zoonado/connection.py
+++ b/zoonado/connection.py
@@ -216,7 +216,7 @@ class Connection(object):
 
     def drain_all_pending(self):
         for special_xid in protocol.SPECIAL_XIDS:
-            for _, f in iterables.drain(self.pending_specials[special_xid]):
+            for f in iterables.drain(self.pending_specials[special_xid]):
                 yield f
         for _, f in iterables.drain(self.pending):
             yield f

--- a/zoonado/recipes/barrier.py
+++ b/zoonado/recipes/barrier.py
@@ -37,7 +37,7 @@ class Barrier(Recipe):
         )
 
         if time_limit:
-            barrier_lifted = gen.with_timeout(barrier_lifted, time_limit)
+            barrier_lifted = gen.with_timeout(time_limit, barrier_lifted)
 
         exists = yield self.client.exists(path=self.path, watch=True)
         if not exists:

--- a/zoonado/recipes/double_barrier.py
+++ b/zoonado/recipes/double_barrier.py
@@ -33,7 +33,7 @@ class DoubleBarrier(SequentialRecipe):
             WatchEvent.CREATED, self.sentinel_path
         )
         if time_limit:
-            barrier_lifted = gen.with_timeout(barrier_lifted, time_limit)
+            barrier_lifted = gen.with_timeout(time_limit, barrier_lifted)
 
         exists = yield self.client.exists(path=self.sentinel_path, watch=True)
 

--- a/zoonado/recipes/election.py
+++ b/zoonado/recipes/election.py
@@ -48,7 +48,7 @@ class LeaderElection(SequentialRecipe):
             time_limit = time.time() + timeout
 
         if time_limit:
-            yield gen.with_timeout(self.leadership_future, time_limit)
+            yield gen.with_timeout(time_limit, self.leadership_future)
         else:
             yield self.leadership_future
 

--- a/zoonado/recipes/sequential.py
+++ b/zoonado/recipes/sequential.py
@@ -78,7 +78,7 @@ class SequentialRecipe(Recipe):
 
         unblocked = self.client.wait_for_event(WatchEvent.DELETED, path)
         if time_limit:
-            unblocked = gen.with_timeout(unblocked, time_limit)
+            unblocked = gen.with_timeout(time_limit, unblocked)
 
         exists = yield self.client.exists(path=path, watch=True)
         if not exists:

--- a/zoonado/session.py
+++ b/zoonado/session.py
@@ -204,7 +204,6 @@ class Session(object):
     def heartbeat(self):
         if self.closing:
             return
-        
         yield self.ensure_safe_state()
 
         try:

--- a/zoonado/session.py
+++ b/zoonado/session.py
@@ -204,7 +204,7 @@ class Session(object):
     def heartbeat(self):
         if self.closing:
             return
-        print "state: %s"%self.state.current_state
+        
         yield self.ensure_safe_state()
 
         try:

--- a/zoonado/session.py
+++ b/zoonado/session.py
@@ -4,7 +4,7 @@ import collections
 import logging
 import random
 
-from tornado import gen, ioloop
+from tornado import gen, ioloop, iostream
 
 from zoonado import protocol, exc
 from .connection import Connection
@@ -204,13 +204,13 @@ class Session(object):
     def heartbeat(self):
         if self.closing:
             return
-
+        print "state: %s"%self.state.current_state
         yield self.ensure_safe_state()
 
         try:
             zxid, _ = yield self.conn.send(protocol.PingRequest())
             self.last_zxid = zxid
-        except exc.ConnectError:
+        except (exc.ConnectError, iostream.StreamClosedError):
             self.state.transition_to(States.SUSPENDED)
         finally:
             self.set_heartbeat()


### PR DESCRIPTION
Not sure if this is exactly how you'd like this solved.  One of the for loops in drain_all_pending was erroneously trying to iterate over tuples.  Once that was fixed the StreamClosedError that occurs when the connection is lost and PingRequest attempts to send on the iostream was occurring, but was not triggering a state change that would inform repair_loop to initiate reconnect attempts.  These changes do repair the connection (when stopping and starting zoonado).  I don't know if you want a test for that.  However for the locking example, after reconnect, the test does not continue where it left off.