### PR TITLE
Allow multiple digits in version number

### DIFF
--- a/zoonado/connection.py
+++ b/zoonado/connection.py
@@ -11,7 +11,7 @@ from tornado import ioloop, iostream, gen, concurrent, tcpclient
 from zoonado import protocol, iterables, exc
 
 
-version_regex = re.compile(r'Zookeeper version: (\d)\.(\d)\.(\d)-.*')
+version_regex = re.compile(r'Zookeeper version: (\d+)\.(\d+)\.(\d+)-.*')
 
 # all requests and responses are prefixed with a 32-bit int denoting size
 size_struct = struct.Struct("!i")


### PR DESCRIPTION
Fixes AttributeError when using zoonado with zookeeper 3.4.11

```
[E 180111 19:31:22 session:112] Couldn't connect to localhost:2181
    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/site-packages/zoonado/session.py", line 110, in make_connection
        yield conn.connect()
      File "/usr/local/lib/python2.7/site-packages/tornado/gen.py", line 1015, in run
        value = future.result()
      File "/usr/local/lib/python2.7/site-packages/tornado/concurrent.py", line 237, in result
        raise_exc_info(self._exc_info)
      File "/usr/local/lib/python2.7/site-packages/tornado/gen.py", line 1024, in run
        yielded = self.gen.send(value)
      File "/usr/local/lib/python2.7/site-packages/zoonado/connection.py", line 63, in connect
        map(int, version_regex.match(version_line).groups())
    AttributeError: 'NoneType' object has no attribute 'groups'
```